### PR TITLE
Center conference icons

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -614,7 +614,7 @@ body.about a.about {
   
 	.conference .icon {
 		width: 35%;
-		padding: 1em 1em 1.75em;
+		padding: 1em 0 1.75em;
 	}
 	
 	.conference .icon .inner {


### PR DESCRIPTION
All conference icons were slightly off-center. This change fixes that.
If this was intentional and desired, please disregard this change, and
I'll submit a new one specific to the PyGotham 2016 logo.
